### PR TITLE
[ActionsDolimeet] fix: coerce trainingsession lib1/lib2 results to array for PHP 8

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -651,6 +651,10 @@ class ActionsDolimeet
 
                 $productIds        = trainingsession_function_lib1();
                 $variousProductIds = trainingsession_function_lib2();
+                // lib1/lib2 return -1 (int) when their required global config is missing;
+                // coerce to [] so the array union below doesn't fatal on PHP 8 (array + int)
+                $productIds        = is_array($productIds) ? $productIds : [];
+                $variousProductIds = is_array($variousProductIds) ? $variousProductIds : [];
                 $out = Form::selectarray('idprod', $productIds + $variousProductIds, '', 1, 0, 0, '', 0, 0, 0, '', 'minwidth100imp maxwidth500 widthcentpercentminusxx');
                 ?>
                 <script>


### PR DESCRIPTION
## Summary

- `trainingsession_function_lib1()` et `trainingsession_function_lib2()` retournent `-1` (int) quand la configuration globale requise est absente.
- Le code appelait directement l'union `$productIds + $variousProductIds` sur ces retours, ce qui est un fatal en PHP 8 (`array + int`).
- Coercion explicite à `[]` via `is_array(...) ? ... : []` avant l'union.

## Test plan

- [ ] Sur un environnement où la configuration globale n'est pas définie, ouvrir le modal de sélection de produit sur une session de formation → plus de fatal PHP 8
- [ ] Sur un environnement configuré, vérifier que la sélection de produits fonctionne toujours normalement