### PR TITLE
#825 [Cert] fix: use tzuserrel for completion certificate dates

### DIFF
--- a/core/modules/dolimeet/dolimeetdocuments/trainingsessiondocument/doc_attendancesheetdocument_odt.modules.php
+++ b/core/modules/dolimeet/dolimeetdocuments/trainingsessiondocument/doc_attendancesheetdocument_odt.modules.php
@@ -117,11 +117,11 @@ class doc_attendancesheetdocument_odt extends SaturneDocumentModel
             $tmpArray['project_ref_label'] = '';
         }
 
-        $tmpArray['date_start'] = dol_print_date($object->date_start, 'dayhour', 'tzuser');
-        $tmpArray['date_end']   = dol_print_date($object->date_end, 'dayhour', 'tzuser');
+        $tmpArray['date_start'] = dol_print_date($object->date_start, 'dayhour', 'tzuserrel');
+        $tmpArray['date_end']   = dol_print_date($object->date_end, 'dayhour', 'tzuserrel');
         $tmpArray['duration']   = convertSecondToTime($object->duration);
 
-        $tmpArray['date_creation'] = dol_print_date(dol_now(), 'dayhour', 'tzuser');
+        $tmpArray['date_creation'] = dol_print_date(dol_now(), 'dayhour', 'tzuserrel');
 
         $moreParam['tmparray']                  = $tmpArray;
         $moreParam['multipleAttendantsSegment'] = ['sessiontrainer', 'trainee'];

--- a/core/modules/dolimeet/dolimeetdocuments/trainingsessiondocument/doc_completioncertificatedocument_odt.modules.php
+++ b/core/modules/dolimeet/dolimeetdocuments/trainingsessiondocument/doc_completioncertificatedocument_odt.modules.php
@@ -122,8 +122,8 @@ class doc_completioncertificatedocument_odt extends SaturneDocumentModel
             $tmpArray['action_nature'] = '';
         }
 
-        $tmpArray['date_start'] = dol_print_date($object->date_start, 'dayhour', 'tzuser');
-        $tmpArray['date_end']   = dol_print_date($object->date_end, 'dayhour', 'tzuser');
+        $tmpArray['date_start'] = dol_print_date($object->date_start, 'dayhour', 'tzuserrel');
+        $tmpArray['date_end']   = dol_print_date($object->date_end, 'dayhour', 'tzuserrel');
         $tmpArray['duration']   = convertSecondToTime($object->duration, 'allhourmin');
 
         $tmpArray['attendant_fullname'] = strtoupper($moreParam['attendant']->lastname) . ' ' . ucfirst($moreParam['attendant']->firstname);
@@ -169,7 +169,7 @@ class doc_completioncertificatedocument_odt extends SaturneDocumentModel
             $tmpArray['mycompany_owner_signature'] = '';
         }
 
-        $tmpArray['date_creation'] = dol_print_date(dol_now(), 'dayhour', 'tzuser');
+        $tmpArray['date_creation'] = dol_print_date(dol_now(), 'dayhour', 'tzuserrel');
 
         $moreParam['tmparray'] = $tmpArray;
 

--- a/core/modules/dolimeet/dolimeetdocuments/trainingsessiondocument/pdf_completioncertificatedocument.modules.php
+++ b/core/modules/dolimeet/dolimeetdocuments/trainingsessiondocument/pdf_completioncertificatedocument.modules.php
@@ -99,7 +99,7 @@ class pdf_completioncertificatedocument extends SaturneDocumentModel
         $pdf->SetXY($this->marge_droite - 5, $posy);
         $pdf->Cell(0, 0, '', 0, 1);
         $pdf->Cell(0, 6, $langs->transnoentities('MadeAt') . ' : ' . $mysoc->town, 0, 1);
-        $pdf->Cell(0, 6, $langs->transnoentities('The') . ' : ' . dol_print_date(dol_now(), 'dayhour', 'tzuser'), 0, 1);
+        $pdf->Cell(0, 6, $langs->transnoentities('The') . ' : ' . dol_print_date(dol_now(), 'dayhour', 'tzuserrel'), 0, 1);
 
         $pdf->SetXY($posX, $posy + 5);
         $signatureStartY = $pdf->GetY();
@@ -240,8 +240,8 @@ class pdf_completioncertificatedocument extends SaturneDocumentModel
         $companyName    = $mysoc->name;
         $formationLabel = $object->formationLabel;
         $contractRef    = $object->ref;
-        $trainingStart  = dol_print_date($object->date_start, 'day', 'tzuser');
-        $trainingEnd    = dol_print_date($object->date_end, 'day', 'tzuser');
+        $trainingStart  = dol_print_date($object->date_start, 'day', 'tzuserrel');
+        $trainingEnd    = dol_print_date($object->date_end, 'day', 'tzuserrel');
         $totalHours     = convertSecondToTime($object->duration, 'allhourmin');
         $actionName     = $langs->trans($trainingSessionDicts[$object->array_options['options_trainingsession_type']]->label);
         $issuerName     = $userTmp->firstname . ' ' . $userTmp->lastname;


### PR DESCRIPTION
## Summary
- Closes #825
- Le certificat de réalisation et la feuille d'émargement affichaient les dates/heures de session en `tzuser` au lieu du fuseau local relatif, créant un décalage horaire visible (effet "GMT") quand le fuseau du serveur diffère de celui du navigateur, et lors des changements d'heure (DST).
- Bascule de `tzuser` vers `tzuserrel` pour `date_start`, `date_end` et `date_creation` dans les générateurs ODT et PDF du `completioncertificatedocument` ainsi que de l'ODT du `attendancesheetdocument`, en cohérence avec le pattern déjà appliqué dans `lib/dolimeet_function.lib.php` (commit 869e37a, #682).

## Test plan
- [ ] Générer un certificat de réalisation ODT depuis un contrat avec sessions planifiées : vérifier que les heures de début/fin affichées correspondent à celles saisies dans le fuseau local.
- [ ] Générer le PDF du certificat : vérifier la date de génération en pied de page et les dates de début/fin de formation.
- [ ] Générer une feuille d'émargement ODT : vérifier les dates de début/fin et la date de création.
- [ ] Vérifier le comportement à cheval sur un changement d'heure (DST) si pertinent.