### PR TITLE
#826 [Session] fix: trainingsession card fatal on '?'-corrupted object_type

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -1041,7 +1041,7 @@ class ActionsDolimeet
             'tab_type'       => 'trainingsession',
             'hook_name_list' => 'trainingsessionlist',
             'hook_name_card' => 'trainingsessioncard',
-            'create_url'     => 'custom/dolimeet/view/trainingsession/session_card.php?action=create&object_type=trainingsession',
+            'create_url'     => 'custom/dolimeet/view/session/session_card.php?action=create&object_type=trainingsession',
             'class_path'     => 'custom/dolimeet/class/trainingsession.class.php'
         ];
         $this->results = $linkableObjectTypes;

--- a/view/session/session_card.php
+++ b/view/session/session_card.php
@@ -32,6 +32,11 @@ if (file_exists('../../dolimeet.main.inc.php')) {
 
 // Get module parameters.
 $objectType = GETPOST('object_type', 'alpha');
+// Strip trailing '?...' that can leak in when an external caller appends '?action=create&backtopage=...'
+// to a create_url that already contained a query string (e.g., digiquali survey/control "+" button).
+if (strpos($objectType, '?') !== false) {
+    $objectType = strstr($objectType, '?', true);
+}
 
 // Load Dolibarr libraries.
 require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';


### PR DESCRIPTION
## Contexte

Closes #826.

Quand le bouton **"+"** (sur le **survey_card** / **control_card** de DigiQuali) construit l'URL de création d'une session de formation, il concatène `?action=create&backtopage=...` à la fin du `create_url` exposé par `extendSheetLinkableObjectsList()`. Comme ce `create_url` contient déjà une query string, l'URL résultante a **deux `?`** :

```
.../view/trainingsession/session_card.php?action=create&object_type=trainingsession?action=create&backtopage=...
```

Le parseur PHP affecte alors :
- `$_GET['action']      = 'create'`
- `$_GET['object_type'] = 'trainingsession?action=create'`
- `$_GET['backtopage']  = '...'`

`GETPOST('object_type', 'alpha')` ne strippe pas le `?`, donc on arrive sur :

```php
require_once __DIR__ . '/../../lib/dolimeet_trainingsession?action=create.lib.php';
```

→ **Fatal** : fichier inexistant (et sous Windows `?` est interdit dans un nom de fichier).

À cela s'ajoutait un second souci dans `extendSheetLinkableObjectsList()` : le chemin pointait vers `view/trainingsession/session_card.php` alors que le fichier réel est dans `view/session/`.

## Changements

- `class/actions_dolimeet.class.php` : corrige le path du `create_url` (`view/trainingsession/` → `view/session/`).
- `view/session/session_card.php` : strippe tout ce qui suit le premier `?` dans `\$objectType` avant qu'il ne soit injecté dans les `require_once` (ligne 34). Défensif côté callee, ce qui protège aussi des autres callers qui auraient le même pattern.

## Test plan

- [x] Reproduction : appel direct `require_once 'dolimeet_trainingsession?action=create.lib.php'` → Fatal confirmé en PHP 7.4 et 8.2.
- [x] Après fix : la sanitisation ramène `$objectType` à `'trainingsession'`, le `require_once` charge le bon fichier en PHP 7.4 et 8.2.
- [ ] Côté UI : cliquer sur le bouton **"+"** à côté du dropdown "Session de formation" dans `survey_card.php` / `control_card.php` de DigiQuali ouvre maintenant le formulaire de création d'une `trainingsession`.
- [ ] Vérifier que les liens existants vers `session_card.php?id=X&object_type=trainingsession` continuent de fonctionner (la sanitisation ne s'active que si `?` est présent dans la valeur).