### PR TITLE
[Session] fix: setCategories targets missing llx_categorie_{element} table on trainingsession create

### DIFF
--- a/class/session.class.php
+++ b/class/session.class.php
@@ -424,6 +424,22 @@ class Session extends SaturneObject
     }
 
     /**
+     * Force category type to 'session' for all session subtypes (trainingsession, meeting, audit).
+     * Dolibarr core (actions_addupdatedelete.inc.php) calls setCategories() without a type, and
+     * SaturneObject falls back to $this->element. The only category link table is llx_categorie_session,
+     * so anything else (e.g. llx_categorie_trainingsession) doesn't exist and fatals.
+     *
+     * @param  int[]|int $categories     Category ID or array of Categories IDs
+     * @param  string    $typeCateg      Category type — defaults to 'session' for this hierarchy
+     * @param  bool      $removeExisting True : remove existing categories not supplied in $categories
+     * @return int                       <0 if KO, >0 if OK
+     */
+    public function setCategories($categories, string $typeCateg = '', bool $removeExisting = false): int
+    {
+        return parent::setCategories($categories, $typeCateg ?: 'session', $removeExisting);
+    }
+
+    /**
      * Set draft status
      *
      * @param  User      $user      Object user that modify


### PR DESCRIPTION
## Contexte

À la création (ou mise à jour) d'une `trainingsession` (idem pour `meeting` / `audit`), Dolibarr core appelle :

```php
// htdocs/core/actions_addupdatedelete.inc.php:226
\$object->setCategories(\$categories);
```

sans préciser le `\$typeCateg`. La méthode parente dans Saturne fait alors :

```php
// custom/saturne/class/saturneobject.class.php:777
\$typeCateg = \$typeCateg ?: \$this->element;
```

Pour un `Trainingsession`, ça retombe sur `\$typeCateg = 'trainingsession'`, donc `setCategoriesCommon` requête sur `llx_categorie_trainingsession`. Or **seule la table `llx_categorie_session` existe** (toutes les sous-classes Session partagent la même table — cf. `sql/session/llx_categorie_session.sql`).

Résultat :
```
DB_ERROR_NOSUCHTABLE: La table 'dolibarr_xxx.llx_categorie_trainingsession' n'existe pas
SQL: SELECT ct.fk_categorie, c.label, c.rowid FROM llx_categorie_trainingsession as ct ...
```
→ `dol_print_error` → page d'erreur.

## Fix

Override `setCategories` dans `Session` pour forcer le fallback à `'session'` (et non `\$this->element`). Un argument `\$typeCateg` explicite passé par un caller reste honoré.

```php
public function setCategories(\$categories, string \$typeCateg = '', bool \$removeExisting = false): int
{
    return parent::setCategories(\$categories, \$typeCateg ?: 'session', \$removeExisting);
}
```

Couvre les trois sous-classes : `Trainingsession`, `Meeting`, `Audit`.

## Test plan

- [x] Unit test (mock CommonObject) : sans override, le parent reçoit `'trainingsession'` → table inexistante. Avec override, il reçoit `'session'` → bonne table.
- [x] Override respecte les appels explicites (`setCategories([], 'customer')` passe `'customer'`).
- [ ] UI : créer une nouvelle session de formation avec ou sans catégorie sélectionnée → plus de `dol_print_error` sur `llx_categorie_trainingsession`.
- [ ] Pareil pour meeting et audit.
- [ ] Editer une trainingsession existante avec catégories → l'association se fait bien dans `llx_categorie_session`.