### PR TITLE
#813 [PublicInterface] add: grant societe.contact.creer to default public interface user

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -762,6 +762,36 @@ class ActionsDolimeet
             }
         }
 
+        if ($parameters['currentcontext'] == 'dolimeetpublicinterfaceadmin') {
+            if ($action == 'set_default_public_interface_user') {
+                $this->ensurePublicInterfaceUserHasContactCreerRight(GETPOSTINT('default_public_interface_user_id'));
+                // Let saturne's publicinterface.php save the const itself.
+            } elseif ($action == 'create_default_public_interface_user') {
+                // Take over saturne's flow so we can grant the right to the newly created user.
+                require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+
+                $userTmp           = new User($this->db);
+                $userTmp->lastname = $langs->transnoentities('DefaultPublicInterfaceUserLastName');
+                $userTmp->login    = 'default_public_interface_user';
+                $userTmp->entity   = 0;
+                $userTmp->employee = 0;
+                $userTmp->setPassword($user);
+
+                $newUserId = $userTmp->create($user);
+                if ($newUserId > 0) {
+                    $this->ensurePublicInterfaceUserHasContactCreerRight($newUserId);
+                    dolibarr_set_const($this->db, 'DOLIMEET_DEFAULT_PUBLIC_INTERFACE_USER', $newUserId, 'integer', 0, '', $conf->entity);
+                    dolibarr_set_const($this->db, 'DOLIMEET_DEFAULT_PUBLIC_INTERFACE_USER_CREATED', $newUserId, 'integer', 0, '', $conf->entity);
+                    setEventMessage($langs->trans('SavedConfig'));
+                } else {
+                    setEventMessages($userTmp->error, $userTmp->errors, 'errors');
+                }
+
+                header('Location: ' . $_SERVER['PHP_SELF'] . '?module_name=DoliMeet');
+                exit;
+            }
+        }
+
         if (strpos($parameters['context'], 'contractcontactcard') !== false) {
             if ($action == 'set_satisfaction_survey' && isModEnabled('digiquali') && version_compare(getDolGlobalString('DIGIQUALI_VERSION'), '1.11.0', '>=')) {
                 require_once __DIR__ . '/../lib/dolimeet_function.lib.php';
@@ -1864,5 +1894,44 @@ class ActionsDolimeet
         }
 
         return 0; // or return 1 to replace standard code.
+    }
+
+    /**
+     * Grant societe.contact.creer to the public interface user so it can create contacts
+     * from public/contact/add_contact.php. Idempotent — User::addrights is a no-op when the
+     * permission is already present.
+     *
+     * @param int $userId User to grant the right to.
+     */
+    private function ensurePublicInterfaceUserHasContactCreerRight(int $userId): void
+    {
+        global $conf;
+
+        if ($userId <= 0) {
+            return;
+        }
+
+        $sql  = 'SELECT id FROM ' . MAIN_DB_PREFIX . 'rights_def';
+        $sql .= " WHERE module = 'societe' AND perms = 'contact' AND subperms = 'creer'";
+        $sql .= ' AND entity = ' . ((int) $conf->entity);
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            return;
+        }
+
+        $row = $this->db->fetch_object($resql);
+        if (!$row) {
+            return;
+        }
+
+        require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+
+        $publicUser = new User($this->db);
+        if ($publicUser->fetch($userId) <= 0) {
+            return;
+        }
+
+        $publicUser->addrights((int) $row->id);
     }
 }


### PR DESCRIPTION
## Contexte

Closes #813.

`public/contact/add_contact.php` (interface publique pour ajouter des stagiaires à un contrat de formation) a besoin que l'utilisateur "interface publique" ait le droit `societe.contact.creer` :

```php
// dolimeet/public/contact/add_contact.php:81-84
\$permissionToCreateContact = \$user->hasRight('societe', 'contact', 'creer');
if (\$permissionToCreateContact == 0) {
    die(\$langs->transnoentities('MissingDefaultUserPublicInterfaceRightsConfig'));
}
```

Or, Saturne (`saturne/admin/publicinterface.php`) crée l'utilisateur par défaut **sans aucun droit** :

```php
\$userTmp->lastname = 'Utilisateur par défaut...';
\$userTmp->login    = 'default_public_interface_user';
\$userTmp->entity   = 0;
\$userTmp->create(\$user); // aucun addrights() après
```

Conséquence : l'admin doit aller manuellement dans \`user/perms.php?id=...\` cocher la perm avant que l'interface publique fonctionne.

## Fix

Hook `ActionsDolimeet::doActions` sur le contexte `dolimeetpublicinterfaceadmin` :

- **`set_default_public_interface_user`** : Saturne ne fait que sauver la const → mon handler accorde la perm à l'utilisateur sélectionné dans le dropdown (idempotent), puis retourne 0 pour laisser Saturne enregistrer la const.
- **`create_default_public_interface_user`** : Saturne crée l'utilisateur puis fait `header('Location'); exit;` — pas de hook post-create disponible. Mon handler reprend le flow complet (create user + set const + set _CREATED + redirect) et ajoute le `addrights()` au passage. Code dupliqué assumé pour rester contenu dans dolimeet.

Helper `ensurePublicInterfaceUserHasContactCreerRight()` :
- Cherche l'`id` du droit `societe.contact.creer` dans `llx_rights_def` pour l'entity courante.
- Appelle `User::addrights(\$id)` — idempotent grâce à `UNIQUE KEY (entity, fk_user, fk_id)` sur `llx_user_rights`.
- `addrights` accorde aussi automatiquement `societe.contact.lire` (héritage \`lire\` sur les perms avec subperm).

## Test plan

- [x] Syntaxe PHP 7.4 et 8.2 OK.
- [x] Helper testé en isolation : ajoute la perm, ré-appel idempotent (count `llx_user_rights` stable), `loadRights()` charge bien `societe->contact->creer = 1`.
- [ ] UI : configurer un user existant via le dropdown → la perm est ajoutée silencieusement.
- [ ] UI : cliquer "Ajouter utilisateur" → nouvel user créé, const positionnée, perm ajoutée, redirection OK.
- [ ] Vérifier que `public/contact/add_contact.php` ne `die()` plus sur `MissingDefaultUserPublicInterfaceRightsConfig`.