### PR TITLE
#831 [Lib] fix: note publique contrat - heures gonflées et sessions dupliquées

### DIFF
--- a/lib/dolimeet_function.lib.php
+++ b/lib/dolimeet_function.lib.php
@@ -130,49 +130,35 @@ function set_public_note(CommonObject $object, Propal $propal = null, $triggerKe
     $nbTrainees      = 0;
     $durations       = 0;
     $publicNotePart2 = '';
-    if ($triggerKey == 'CONTRACT_CREATE') {
-        foreach ($propal->lines as $line) {
-            if (!in_array($line->fk_product, array_keys($productIds))) {
-                continue;
+
+    // On contract creation the formation lines come from the linked proposal, otherwise from the object itself
+    $lines = ($triggerKey == 'CONTRACT_CREATE') ? $propal->lines : $object->lines;
+
+    if ($object->element === 'contrat') {
+        // A contract owns its own (already cloned) sessions, all linked by fk_contrat. They must be fetched once,
+        // independently of the number of formation lines, otherwise the same sessions are summed several times
+        // (inflated durations and duplicated sessions in the note).
+        foreach ($lines as $line) {
+            if (in_array($line->fk_product, array_keys($productIds))) {
+                $formationTitle .= ($triggerKey == 'CONTRACT_CREATE' && dol_strlen($line->product_label) > 0) ? $line->product_label : $line->label;
             }
+        }
 
-            if ($object->element === 'contrat') {
-                $filter = 't.fk_contrat = ' . $object->id;
-            } else {
-                $filter = 't.status = 1 AND t.model = 1 AND t.element_type = \'service\' AND t.fk_element = ' . (int) $line->fk_product;
-            }
-
-            $trainingSessions = $trainingSession->fetchAll('ASC', 'position', 0, 0, ['customsql' => $filter]);
-            if (!is_array($trainingSessions) || empty($trainingSessions)) {
-                continue;
-            }
-
-            $formationTitle .= $line->product_label;
-
-            $nbTrainees += count($trainingSessions);
-            foreach ($trainingSessions as $trainingSession) {
-                $durations += $trainingSession->duration;
-                if ($object->element == 'contrat') {
-                    $publicNotePart2Date = dol_print_date($trainingSession->date_start, 'day', 'tzuserrel') . ' - <strong>' . $langs->transnoentities('Validated') . '</strong>';
-                } else {
-                    $publicNotePart2Date = 'JJ/MM/AAAA - <strong>' . $langs->transnoentities('ToBePlanned') . '</strong>';
-                }
-                $publicNotePart2 .= $publicNotePart2Date . ' - ' . $trainingSession->label . ' : ' . $langs->transnoentities('HourStart') . ' : <strong>' . dol_print_date($trainingSession->date_start, 'hour', 'tzuserrel') . '</strong> - ' . $langs->transnoentities('HourEnd') . ' : <strong>' . dol_print_date($trainingSession->date_end, 'hour', 'tzuserrel') . '</strong><br />';
+        $trainingSessions = $trainingSession->fetchAll('ASC', 'position', 0, 0, ['customsql' => 't.fk_contrat = ' . (int) $object->id]);
+        if (is_array($trainingSessions) && !empty($trainingSessions)) {
+            $nbTrainees = count($trainingSessions);
+            foreach ($trainingSessions as $contractTrainingSession) {
+                $durations       += $contractTrainingSession->duration;
+                $publicNotePart2 .= dol_print_date($contractTrainingSession->date_start, 'day', 'tzuserrel') . ' - <strong>' . $langs->transnoentities('Validated') . '</strong>' . ' - ' . $contractTrainingSession->label . ' : ' . $langs->transnoentities('HourStart') . ' : <strong>' . dol_print_date($contractTrainingSession->date_start, 'hour', 'tzuserrel') . '</strong> - ' . $langs->transnoentities('HourEnd') . ' : <strong>' . dol_print_date($contractTrainingSession->date_end, 'hour', 'tzuserrel') . '</strong><br />';
             }
         }
     } else {
-        foreach ($object->lines as $line) {
+        foreach ($lines as $line) {
             if (!in_array($line->fk_product, array_keys($productIds))) {
                 continue;
             }
 
-            if ($object->element === 'contrat') {
-                $filter = 't.fk_contrat = ' . $object->id;
-            } else {
-                $filter = 't.status = 1 AND t.model = 1 AND t.element_type = \'service\' AND t.fk_element = ' . (int) $line->fk_product;
-            }
-
-            $trainingSessions = $trainingSession->fetchAll('ASC', 'position', 0, 0, ['customsql' => $filter]);
+            $trainingSessions = $trainingSession->fetchAll('ASC', 'position', 0, 0, ['customsql' => 't.status = 1 AND t.model = 1 AND t.element_type = \'service\' AND t.fk_element = ' . (int) $line->fk_product]);
             if (!is_array($trainingSessions) || empty($trainingSessions)) {
                 continue;
             }
@@ -180,14 +166,9 @@ function set_public_note(CommonObject $object, Propal $propal = null, $triggerKe
             $formationTitle .= $line->label;
 
             $nbTrainees += count($trainingSessions);
-            foreach ($trainingSessions as $trainingSession) {
-                $durations += $trainingSession->duration;
-                if ($object->element == 'contrat') {
-                    $publicNotePart2Date = dol_print_date($trainingSession->date_start, 'day', 'tzuserrel') . ' - <strong>' . $langs->transnoentities('Validated') . '</strong>';
-                } else {
-                    $publicNotePart2Date = 'JJ/MM/AAAA - <strong>' . $langs->transnoentities('ToBePlanned') . '</strong>';
-                }
-                $publicNotePart2 .= $publicNotePart2Date . ' - ' . $trainingSession->label . ' : ' . $langs->transnoentities('HourStart') . ' : <strong>' . dol_print_date($trainingSession->date_start, 'hour', 'tzuserrel') . '</strong> - ' . $langs->transnoentities('HourEnd') . ' : <strong>' . dol_print_date($trainingSession->date_end, 'hour', 'tzuserrel') . '</strong><br />';
+            foreach ($trainingSessions as $modelTrainingSession) {
+                $durations       += $modelTrainingSession->duration;
+                $publicNotePart2 .= 'JJ/MM/AAAA - <strong>' . $langs->transnoentities('ToBePlanned') . '</strong>' . ' - ' . $modelTrainingSession->label . ' : ' . $langs->transnoentities('HourStart') . ' : <strong>' . dol_print_date($modelTrainingSession->date_start, 'hour', 'tzuserrel') . '</strong> - ' . $langs->transnoentities('HourEnd') . ' : <strong>' . dol_print_date($modelTrainingSession->date_end, 'hour', 'tzuserrel') . '</strong><br />';
             }
         }
     }


### PR DESCRIPTION
Fixe #831.

## Problème
Dans `set_public_note()` ([lib/dolimeet_function.lib.php]), pour un objet `contrat` la fonction bouclait sur les lignes (`propal->lines` ou `object->lines`) et refaisait à **chaque ligne** une requête filtrée sur `t.fk_contrat = <id>` — filtre indépendant de la ligne, qui renvoie donc **toutes** les sessions du contrat à chaque itération.

Conséquences quand le contrat a plusieurs lignes de service formation :
- durées additionnées plusieurs fois → « 63h alors que j'en ai 14 »
- mêmes sessions répétées dans la note → « des sessions qui se sont rajoutées »
- compteur de sessions (`$nbTrainees`) gonflé

## Correctif
- Pour un `contrat` : les sessions (déjà clonées et liées par `fk_contrat`) sont récupérées **une seule fois**, hors de la boucle sur les lignes. Les lignes ne servent plus qu'à concaténer l'intitulé de formation.
- Le cas propale/modèle (filtre par `fk_element`) reste inchangé.
- Bonus : repli sur `$line->label` quand `product_label` est vide (corrige l'intitulé de formation perdu), et fin du réemploi de la variable `$trainingSession` comme variable de boucle (clobbering).

## À vérifier / hors périmètre
- Le « 2 stagiaires sur 6 » : la note est bien régénérée à l'ajout d'un TRAINEE (`CONTRAT_ADD_CONTACT`) ; ce symptôme était probablement un effet de bord de l'affichage dupliqué. À reconfirmer côté interface publique après ce fix.

## Test plan
- [ ] Contrat avec 1 ligne formation → durée = somme réelle des sessions, chaque session listée une fois
- [ ] Contrat avec 2+ lignes formation → durée non multipliée, pas de session en double
- [ ] Ajout de stagiaires via interface publique → liste complète dans la note
- [ ] Propale (PROPAL_CREATE) → note modèle inchangée