### PR TITLE
#705 [Trigger] fix: description vide sur les services des conventions de formation

### DIFF
--- a/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
+++ b/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
@@ -255,7 +255,7 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
                             $propalLine->fk_parent_line = 0;
                             $propalLine->fk_product     = $product->id;
                             $propalLine->product_label  = $product->label;
-                            $propalLine->desc           = $product->description;
+                            $propalLine->desc           = dol_strlen($product->description) > 0 ? $product->description : $product->label;
                             $propalLine->tva_tx         = $product->tva_tx;
                             $propalLine->qty            = 1;
                             $propalLine->rang           = $formationService['position'];
@@ -296,7 +296,7 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
                             $result   = $product->fetch(getDolGlobalInt($confName));
 
                             if ($result > 0) {
-                                $contratLigne->description = $product->description;
+                                $contratLigne->description = dol_strlen($product->description) > 0 ? $product->description : $product->label;
                                 $contratLigne->subprice    = $product->price;
                                 $contratLigne->qty         = 1;
                                 $contratLigne->tva_tx      = $product->tva_tx;


### PR DESCRIPTION
Fixe #705.

## Problème
Sur certaines entités, les produits de service formation (`FOR_ADM_*`) ont un champ **Description vide** (seul le **Libellé** est renseigné). Le trigger copiait uniquement `$product->description` sur les lignes de propale/contrat, et `Contrat::addline` force `label=''` sur la ligne → la ligne de service de la convention s'affiche **sans aucune description**.

Vérifié en BDD (`dolibarr_demodoli_23`) : entités 20/22/23/24/25, produits `FOR_ADM_*` → `description` length 0, `label` length > 0.

## Correctif
Repli sur le libellé du produit quand la description est vide, aux deux endroits où les lignes formation sont créées :
- `PROPAL_CREATE` (ligne ~258)
- `CONTRACT_CREATE` (ligne ~299)

```php
$desc = dol_strlen($product->description) > 0 ? $product->description : $product->label;
```

## Test (BDD locale)
Produit 77 `FOR_ADM_CF1` (entité 20) : description vide → ancien comportement = ligne vide ; nouveau = `Convention de formation` (le label). ✓

## Test plan
- [ ] Convention créée à partir d'un produit formation sans description → la ligne affiche le libellé
- [ ] Convention avec produit ayant une description → comportement inchangé (description affichée)