### PR TITLE
#828 [Trigger] fix: aperçu du contenu formation sur propale brouillon (note non régénérée)

### DIFF
--- a/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
+++ b/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
@@ -231,6 +231,29 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
                 }
                 break;
 
+            case 'LINEPROPAL_INSERT' :
+            case 'LINEPROPAL_UPDATE' :
+            case 'LINEPROPAL_DELETE' :
+                // Keep the formation public note in sync on a draft proposal so the content is previewable before validation.
+                // NB: only line triggers are used here. PROPAL_MODIFY must NOT, because set_public_note() calls
+                // update_note() which itself fires PROPAL_MODIFY -> infinite recursion.
+                require_once __DIR__ . '/../../lib/dolimeet_function.lib.php';
+                require_once DOL_DOCUMENT_ROOT . '/comm/propal/class/propal.class.php';
+
+                // $object is a PropaleLigne on LINEPROPAL_*
+                $propalId = !empty($object->fk_propal) ? $object->fk_propal : $object->id;
+                if ($propalId > 0) {
+                    $propal = new Propal($this->db);
+                    if ($propal->fetch($propalId) > 0) {
+                        $propal->fetch_lines();
+                        $propal->fetch_optionals();
+                        if ($propal->statut == Propal::STATUS_DRAFT && !empty($propal->array_options['options_trainingsession_type'])) {
+                            set_public_note($propal, $propal, 'PROPAL_CREATE');
+                        }
+                    }
+                }
+                break;
+
             case 'PROPAL_CREATE' :
                 if (GETPOST('options_trainingsession_type', 'int') > 0) {
 

--- a/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
+++ b/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
@@ -232,11 +232,11 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
                 break;
 
             case 'LINEPROPAL_INSERT' :
-            case 'LINEPROPAL_UPDATE' :
+            case 'LINEPROPAL_MODIFY' :
             case 'LINEPROPAL_DELETE' :
                 // Keep the formation public note in sync on a draft proposal so the content is previewable before validation.
-                // NB: only line triggers are used here. PROPAL_MODIFY must NOT, because set_public_note() calls
-                // update_note() which itself fires PROPAL_MODIFY -> infinite recursion.
+                // NB: line update fires LINEPROPAL_MODIFY (not _UPDATE). PROPAL_MODIFY must NOT be used here, because
+                // set_public_note() calls update_note() which itself fires PROPAL_MODIFY -> infinite recursion.
                 require_once __DIR__ . '/../../lib/dolimeet_function.lib.php';
                 require_once DOL_DOCUMENT_ROOT . '/comm/propal/class/propal.class.php';
 

--- a/lib/dolimeet_function.lib.php
+++ b/lib/dolimeet_function.lib.php
@@ -163,7 +163,7 @@ function set_public_note(CommonObject $object, Propal $propal = null, $triggerKe
                 continue;
             }
 
-            $formationTitle .= $line->label;
+            $formationTitle .= dol_strlen($line->label) > 0 ? $line->label : $line->product_label;
 
             $nbTrainees += count($trainingSessions);
             foreach ($trainingSessions as $modelTrainingSession) {


### PR DESCRIPTION
Fixe #828.

## Problème
Sur une propale (PR) de formation, le contenu des services / la note publique ne se remplissait **qu'à la création** (`PROPAL_CREATE`, qui dépend d'un POST précis) et n'était **jamais régénéré** quand on modifiait la propale brouillon. Résultat : pas d'aperçu avant validation, contenu vide, obligation de tout retoucher après.

## Correctif
1. **Régénération de la note** sur `LINEPROPAL_INSERT` / `LINEPROPAL_UPDATE` / `LINEPROPAL_DELETE`, uniquement pour une propale **brouillon** (`statut = 0`) de formation (`options_trainingsession_type` renseigné). Le contenu est ainsi à jour/visible avant validation.
2. **Titre formation** : repli sur `product_label` quand la ligne n'a pas de `label` (l'« Objet de la formation » s'affichait vide sur les propales).

⚠️ `PROPAL_MODIFY` est volontairement **exclu** : `set_public_note()` appelle `update_note()` qui re-déclenche `PROPAL_MODIFY` → **boucle infinie** (détectée et reproduite en test local).

## Test (BDD locale `dolibarr_demodoli_23`)
Propale brouillon 90 (note vide) → `runTrigger('LINEPROPAL_UPDATE', ...)` → note régénérée (1264 caractères), titre formation rempli (« Formation ultime »). Pas de récursion après exclusion de `PROPAL_MODIFY`.

## Limite connue
Modifier uniquement le type/lieu de formation (sans toucher aux lignes) ne rafraîchit pas la note (par sécurité anti-récursion). À voir si on veut couvrir ce cas via un autre mécanisme.

## Test plan
- [ ] Propale brouillon formation : ajouter/modifier/supprimer une ligne → la note publique reflète le contenu
- [ ] Propale non-formation → aucun effet
- [ ] Propale validée → pas de régénération
- [ ] Pas de boucle / lenteur anormale à l'édition de lignes