### PR TITLE
[Lib] fix: dépréciation PHP 8.4 (paramètre nullable implicite)

### DIFF
--- a/lib/dolimeet_function.lib.php
+++ b/lib/dolimeet_function.lib.php
@@ -105,7 +105,7 @@ function get_formation_service(): array
  *
  * @throws Exception
  */
-function set_public_note(CommonObject $object, Propal $propal = null, $triggerKey = '')
+function set_public_note(CommonObject $object, ?Propal $propal = null, $triggerKey = '')
 {
     global $conf, $db, $langs;
 


### PR DESCRIPTION
## Problème
PHP 8.4+ déprécie les paramètres typés nullable implicites (`Type \$x = null`). `set_public_note()` déclarait `Propal \$propal = null`, ce qui émet :

> Deprecated: Implicitly marking parameter \$propal as nullable is deprecated, the explicit nullable type must be used instead

## Correctif
`Propal \$propal = null` → `?Propal \$propal = null`. Syntaxe valide dès PHP 7.1 (compatible avec la cible PHP 7.4 du module), supprime la dépréciation 8.4/8.5 et évite l'erreur future en PHP 9.

## Vérif
- `php -l` (PHP 8.5.1) : plus de `Deprecated`.
- Scan complet du module : plus aucune occurrence de ce type de dépréciation.
- Changement purement déclaratif (annotation de type), comportement identique.