### PR TITLE
#816 [Trigger] add: trigger sur le retrait d'un contact du contrat (miroir de l'ajout)

### DIFF
--- a/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
+++ b/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
@@ -231,6 +231,61 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
                 }
                 break;
 
+            case 'CONTRAT_DELETE_CONTACT' :
+                // Mirror of CONTRAT_ADD_CONTACT: when a contact is unlinked from a training contract, drop its
+                // signatory on the draft sessions and refresh the public note.
+                if (isset($object->array_options['options_trainingsession_type']) && !empty($object->array_options['options_trainingsession_type'])) {
+                    require_once __DIR__ . '/../../lib/dolimeet_function.lib.php';
+                    require_once __DIR__ . '/../../class/trainingsession.class.php';
+                    require_once __DIR__ . '/../../../saturne/class/saturnesignature.class.php';
+
+                    // The trigger fires BEFORE the element_contact row is deleted: resolve the unlinked contact from the link id (still present)
+                    $linkId = (int) ($object->context['contact_id'] ?? 0);
+                    if ($linkId > 0) {
+                        $sql  = 'SELECT ec.fk_socpeople AS contactid, tc.code AS code, tc.source AS source';
+                        $sql .= ' FROM ' . MAIN_DB_PREFIX . 'element_contact AS ec';
+                        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'c_type_contact AS tc ON tc.rowid = ec.fk_c_type_contact';
+                        $sql .= ' WHERE ec.rowid = ' . $linkId;
+                        $resql = $this->db->query($sql);
+                        if ($resql && $this->db->num_rows($resql) > 0) {
+                            $contactObj    = $this->db->fetch_object($resql);
+                            $contactID     = (int) $contactObj->contactid;
+                            $contactCode   = $contactObj->code;
+                            $contactSource = $contactObj->source;
+
+                            // Remove this specific contact's signatory from the contract draft sessions
+                            if ($contactCode == 'TRAINEE' || $contactCode == 'SESSIONTRAINER') {
+                                $trainingSession = new Trainingsession($this->db);
+                                $signatory       = new SaturneSignature($this->db, 'dolimeet', $trainingSession->element);
+                                $role            = ($contactCode == 'TRAINEE') ? 'Trainee' : 'SessionTrainer';
+                                $elementType     = ($contactSource == 'internal') ? 'user' : 'socpeople';
+
+                                $trainingSessions = $trainingSession->fetchAll('', '', 0, 0, ['customsql' => 't.status = ' . Session::STATUS_DRAFT . ' AND t.fk_contrat = ' . $object->id]);
+                                if (is_array($trainingSessions) && !empty($trainingSessions)) {
+                                    foreach ($trainingSessions as $session) {
+                                        $signatories = $signatory->fetchAll('', '', 0, 0, ['customsql' => "fk_object = " . $session->id . " AND object_type = '" . $trainingSession->element . "' AND role = '" . $role . "' AND element_id = " . $contactID . " AND element_type = '" . $elementType . "' AND status = 1"]);
+                                        if (is_array($signatories) && !empty($signatories)) {
+                                            foreach ($signatories as $signatoryToDelete) {
+                                                $signatoryToDelete->setDeleted($user, true);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Refresh the public note, excluding the trainee being removed (its link is not deleted yet)
+                            if ($contactCode == 'TRAINEE') {
+                                $object->fetchObjectLinked(null, 'propal', $object->id, 'contrat');
+                                if (isset($object->linkedObjects['propal']) && !empty($object->linkedObjects['propal']) && count($object->linkedObjects['propal']) == 1) {
+                                    $propal = array_shift($object->linkedObjects['propal']);
+                                    set_public_note($object, $propal, '', $contactID);
+                                }
+                            }
+                        }
+                    }
+                }
+                break;
+
             case 'LINEPROPAL_INSERT' :
             case 'LINEPROPAL_MODIFY' :
             case 'LINEPROPAL_DELETE' :

--- a/lib/dolimeet_function.lib.php
+++ b/lib/dolimeet_function.lib.php
@@ -100,12 +100,14 @@ function get_formation_service(): array
 /**
  * Set public note on project/propal/contract
  *
- * @param CommonObject $object  Object
- * @param Propal|null  $propal  Propal object (optional)
+ * @param CommonObject $object           Object
+ * @param Propal|null  $propal           Propal object (optional)
+ * @param string       $triggerKey       Trigger key the note is rebuilt from
+ * @param int          $excludeContactId Trainee contact id to exclude (e.g. on contact unlink, fired before the link is removed)
  *
  * @throws Exception
  */
-function set_public_note(CommonObject $object, ?Propal $propal = null, $triggerKey = '')
+function set_public_note(CommonObject $object, ?Propal $propal = null, $triggerKey = '', $excludeContactId = 0)
 {
     global $conf, $db, $langs;
 
@@ -188,9 +190,18 @@ function set_public_note(CommonObject $object, ?Propal $propal = null, $triggerK
     // Part 3 - Trainee list
     $internalTrainee = $object->liste_contact(-1, 'internal', 0, 'TRAINEE');
     $externalTrainee = $object->liste_contact(-1, 'external', 0, 'TRAINEE');
-    if ((is_array($internalTrainee) && !empty($internalTrainee)) || (is_array($externalTrainee) && !empty($externalTrainee))) {
+    $contacts        = array_merge(
+        (is_array($internalTrainee) ? $internalTrainee : []),
+        (is_array($externalTrainee) ? $externalTrainee : [])
+    );
+    // On contact unlink the trigger fires before the link is removed: exclude the trainee being removed
+    if ($excludeContactId > 0) {
+        $contacts = array_filter($contacts, function ($contact) use ($excludeContactId) {
+            return (int) $contact['id'] !== (int) $excludeContactId;
+        });
+    }
+    if (!empty($contacts)) {
         $object->note_public .= '<br />' . $langs->transnoentities('PublicNoteTraineeList') . '<br />';
-        $contacts = array_merge($internalTrainee, $externalTrainee);
         $object->note_public .= $langs->transnoentities('TrainingSessionNbTrainees') . ' : ' . count($contacts) . '<br /><ul>';
         foreach ($contacts as $contact) {
             //@todo option pour le mail


### PR DESCRIPTION
Fixe #816.

## Besoin
Symétrique de `CONTRAT_ADD_CONTACT` : quand on **retire** un contact d'une convention de formation, faire le ménage comme à l'ajout.

## Correctif
Ajout du case `CONTRAT_DELETE_CONTACT` dans le trigger :
- Résout le contact retiré depuis le `rowid` du lien `element_contact` (le trigger se déclenche **avant** la suppression du lien — vérifié dans le core `CommonObject::delete_contact`).
- Pour un TRAINEE/SESSIONTRAINER : supprime **son** signataire (ciblé sur `element_id`/`element_type`/`role`) sur les sessions de formation **brouillon** du contrat.
- Pour un TRAINEE : régénère la note publique.

`set_public_note()` reçoit un paramètre `$excludeContactId` : comme le trigger précède la suppression effective du lien, on exclut le stagiaire en cours de retrait de la liste (sinon il apparaîtrait encore). Défaut `0` → aucun impact sur les autres appels.

Pas de récursion : `set_public_note()`→`update_note()` fire `CONTRAT_MODIFY` (non géré ici).

## Test (BDD locale, contrat 13)
Retrait du stagiaire 17 (via son lien) :
- signataires actifs du contact sur sessions brouillon : **11 → 0**
- stagiaires listés dans la note : **2 → 1** (le stagiaire retiré est bien exclu)
- `runTrigger` retourne 0, état restauré après test

Nom d'événement, `context['contact_id']` (= rowid du lien) et timing avant-suppression **vérifiés dans le core** → le test reflète le vrai flux d'unlink.

## Test plan
- [ ] Retirer un stagiaire d'une convention → il disparaît de la note + son signataire est retiré des sessions brouillon
- [ ] Retirer un formateur (SESSIONTRAINER) → son signataire est retiré (note inchangée)
- [ ] Les autres stagiaires/formateurs conservent leur signataire