### PR TITLE
#741 [Lib] fix: champ 'objet de la formation' vide sur la note de contrat

### DIFF
--- a/lib/dolimeet_function.lib.php
+++ b/lib/dolimeet_function.lib.php
@@ -142,7 +142,7 @@ function set_public_note(CommonObject $object, ?Propal $propal = null, $triggerK
         // (inflated durations and duplicated sessions in the note).
         foreach ($lines as $line) {
             if (in_array($line->fk_product, array_keys($productIds))) {
-                $formationTitle .= ($triggerKey == 'CONTRACT_CREATE' && dol_strlen($line->product_label) > 0) ? $line->product_label : $line->label;
+                $formationTitle .= dol_strlen($line->product_label) > 0 ? $line->product_label : $line->label;
             }
         }
 


### PR DESCRIPTION
Fixe #741.

## Problème
Sur la note d'un **contrat** (convention), le champ « Objet de la formation : » est **vide**. Cause : hors `CONTRACT_CREATE`, le titre était construit à partir de `$line->label`, or `Contrat::addline` force `label=''` sur les lignes de contrat (même racine que #705). Le titre restait donc vide à chaque régénération de la note d'un contrat existant (validation session, ajout/retrait de contact…).

## Correctif
Construire le titre à partir de `$line->product_label` (peuplé par `Contrat::fetch_lines()` depuis le libellé produit) avec repli sur `$line->label` :
```php
$formationTitle .= dol_strlen($line->product_label) > 0 ? $line->product_label : $line->label;
```
Fonctionne pour tous les déclencheurs (CONTRACT_CREATE = lignes de propale, autres = lignes de contrat).

## Test (BDD locale, contrat 13)
- Ancien code : « Objet de la formation » = **''** (vide)
- Code corrigé : « Objet de la formation » = **Formation ultime** ✓

## Hors périmètre (à confirmer)
L'annotation de l'issue mentionne « modifiable en extrafields ». Ce PR corrige le **calcul** (le vide). Permettre une **surcharge via extrafield** dédié serait une feature séparée (création d'un extrafield + lecture dans `set_public_note`) — à cadrer si souhaité.