### PR TITLE
#793 [Session] fix: afficher 'Signé' quand tous les participants ont signé

### DIFF
--- a/class/session.class.php
+++ b/class/session.class.php
@@ -493,6 +493,19 @@ class Session extends SaturneObject
             $statusType = 'status8';
         }
 
+        // When validated and every attendant has signed, show "Signé" instead of "Validé (en attente de signature)"
+        if ($status == self::STATUS_VALIDATED && $status == $this->status && $this->id > 0) {
+            require_once __DIR__ . '/../../saturne/class/saturnesignature.class.php';
+
+            $signatory = new SaturneSignature($this->db, 'dolimeet', $this->element);
+            if ($signatory->checkSignatoriesSignatures($this->id, $this->element) == 1) {
+                global $langs;
+                $langs->load('signature@saturne');
+                $signedLabel = $langs->transnoentitiesnoconv('Signed');
+                return dolGetStatus($signedLabel, $signedLabel, '', 'status4', $mode);
+            }
+        }
+
         return dolGetStatus($this->labelStatus[$status], $this->labelStatusShort[$status], '', $statusType, $mode);
     }
 


### PR DESCRIPTION
Fixe #793.

## Problème
Une session restait affichée « Validé (en attente de signature) » même quand **tous** les participants avaient signé (cf capture : tous au vert, badge toujours « en attente »). Le label du statut `STATUS_VALIDATED` était **statique**.

## Correctif (label dynamique, display-only)
Dans `Session::LibStatut()`, quand la session est au statut Validé **et** que `checkSignatoriesSignatures()` confirme que tous les participants ont signé (ou sont absents), on affiche **« Signé »** (badge vert) au lieu de « Validé (en attente de signature) ».

Le **statut réel et le workflow ne changent pas** (pas de verrouillage auto, pas de nouveau statut en base) — c'est purement l'affichage qui devient cohérent.

## Test (BDD locale)
- Session 5 (1 participant, signé) → **« Signé »** ✓
- Session 11 (1 participant, non signé) → « Validé (en attente de signature) » (inchangé) ✓

## Note
`checkSignatoriesSignatures()` fait une requête : en vue liste, c'est une requête par ligne. Acceptable pour l'usage, à surveiller si listes très volumineuses.

## Test plan
- [ ] Session validée, tous signés → badge « Signé » (vert)
- [ ] Session validée, au moins un non signé → « Validé (en attente de signature) »
- [ ] Session brouillon / verrouillée / archivée → libellés inchangés