### PR TITLE
#563 [Trigger] fix: remove session signatories when a contact is removed from a formation contract

### DIFF
--- a/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
+++ b/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
@@ -231,6 +231,51 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
                 }
                 break;
 
+            case 'CONTRAT_DELETE_CONTACT' :
+                require_once __DIR__ . '/../../class/trainingsession.class.php';
+                require_once __DIR__ . '/../../../saturne/class/saturnesignature.class.php';
+
+                // Session signatories only exist for formation contracts, so gate on the presence of draft sessions rather than on the trainingsession_type extrafield (it can be empty while sessions still carry signatories created by TRAININGSESSION_CREATE)
+                $trainingSession  = new Trainingsession($this->db);
+                $trainingSessions = $trainingSession->fetchAll('', '', 0, 0, ['customsql' => 't.status = ' . Session::STATUS_DRAFT . ' AND t.fk_contrat = ' . $object->id]);
+                if (is_array($trainingSessions) && !empty($trainingSessions)) {
+                    // The element_contact link still exists at trigger time (core removes it after the trigger), so the removed contact can still be resolved
+                    $contactLineID    = $object->context['contact_id'] ?? 0;
+                    $internalContacts = $object->liste_contact(-1, 'internal');
+                    $externalContacts = $object->liste_contact(-1, 'external');
+                    $contacts         = array_merge(
+                        is_array($internalContacts) ? $internalContacts : [],
+                        is_array($externalContacts) ? $externalContacts : []
+                    );
+
+                    $removedContact = [];
+                    foreach ($contacts as $contact) {
+                        if ($contact['rowid'] == $contactLineID) {
+                            $removedContact = $contact;
+                            break;
+                        }
+                    }
+
+                    if (!empty($removedContact) && ($removedContact['code'] == 'TRAINEE' || $removedContact['code'] == 'SESSIONTRAINER')) {
+                        $signatory     = new SaturneSignature($this->db, 'dolimeet', $trainingSession->element);
+                        $signatoryRole = ($removedContact['code'] == 'TRAINEE') ? 'Trainee' : 'SessionTrainer';
+                        $elementType   = ($removedContact['source'] == 'internal') ? 'user' : 'socpeople';
+
+                        // Remove the signatory created for this contact on each draft session of the contract (mirror of CONTRAT_ADD_CONTACT / TRAININGSESSION_CREATE)
+                        foreach ($trainingSessions as $trainingSession) {
+                            $sessionSignatories = $signatory->fetchSignatory($signatoryRole, $trainingSession->id, $trainingSession->element);
+                            if (is_array($sessionSignatories) && !empty($sessionSignatories)) {
+                                foreach ($sessionSignatories as $sessionSignatory) {
+                                    if ($sessionSignatory->element_id == $removedContact['id'] && $sessionSignatory->element_type == $elementType) {
+                                        $sessionSignatory->setDeleted($user, true);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                break;
+
             case 'PROPAL_CREATE' :
                 if (GETPOST('options_trainingsession_type', 'int') > 0) {
 


### PR DESCRIPTION
Closes #563

## Problème
Quand un contact `TRAINEE`/`SESSIONTRAINER` était retiré d'un contrat (convention) de formation, le signataire SaturneSignature créé sur chaque session brouillon (par `CONTRAT_ADD_CONTACT` et `TRAININGSESSION_CREATE`) restait orphelin : **aucun handler `CONTRAT_DELETE_CONTACT`** n'existait. Ces signataires fantômes continuaient d'apparaître dans les mails de questionnaires/convocation (`functions_dolimeet.lib.php`) et autres sorties basées sur `fetchSignatory()`.

## Correctif
Ajout d'un handler `CONTRAT_DELETE_CONTACT` qui :
- résout le contact retiré (son lien `element_contact` existe encore au moment du trigger, la suppression coeur ayant lieu après) ;
- pour un `TRAINEE`/`SESSIONTRAINER`, soft-delete (`setDeleted`, status=-1) **son** signataire sur chaque session brouillon du contrat.

Le garde porte sur la **présence de sessions brouillon** (et non sur l'extrafield `trainingsession_type`, qui peut valoir 0 sur des contrats formation dont les signataires viennent de `TRAININGSESSION_CREATE`). No-op pour les contrats non-formation. Seul le signataire du contact retiré est supprimé, les autres participants sont préservés.

## Vérification (instance locale, transactions annulées)
- 124 signataires orphelins constatés sur sessions brouillon (~20 contrats) → preuve du bug.
- Retrait d'un stagiaire (contrat à 1 stagiaire) → signataire passe `status 1 → -1`, exclu de `fetchSignatory (status>0)`. ✅
- Retrait d'1 stagiaire sur 12 (contrat `trainingsession_type=0`) → **seul** le sien est supprimé, les 11 autres intacts. ✅
- Rollback → données strictement inchangées. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)