### PR TITLE
#845 [Trigger] fix: gate CONTRAT_DELETE_CONTACT signatory cleanup on draft sessions, not trainingsession_type

### DIFF
--- a/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
+++ b/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
@@ -234,11 +234,14 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
             case 'CONTRAT_DELETE_CONTACT' :
                 // Mirror of CONTRAT_ADD_CONTACT: when a contact is unlinked from a training contract, drop its
                 // signatory on the draft sessions and refresh the public note.
-                if (isset($object->array_options['options_trainingsession_type']) && !empty($object->array_options['options_trainingsession_type'])) {
-                    require_once __DIR__ . '/../../lib/dolimeet_function.lib.php';
-                    require_once __DIR__ . '/../../class/trainingsession.class.php';
-                    require_once __DIR__ . '/../../../saturne/class/saturnesignature.class.php';
+                require_once __DIR__ . '/../../lib/dolimeet_function.lib.php';
+                require_once __DIR__ . '/../../class/trainingsession.class.php';
+                require_once __DIR__ . '/../../../saturne/class/saturnesignature.class.php';
 
+                // Gate on the presence of draft sessions, not on the trainingsession_type extrafield: it can be empty on formation contracts whose session signatories were created by TRAININGSESSION_CREATE.
+                $trainingSession  = new Trainingsession($this->db);
+                $trainingSessions = $trainingSession->fetchAll('', '', 0, 0, ['customsql' => 't.status = ' . Session::STATUS_DRAFT . ' AND t.fk_contrat = ' . $object->id]);
+                if (is_array($trainingSessions) && !empty($trainingSessions)) {
                     // The trigger fires BEFORE the element_contact row is deleted: resolve the unlinked contact from the link id (still present)
                     $linkId = (int) ($object->context['contact_id'] ?? 0);
                     if ($linkId > 0) {
@@ -255,26 +258,22 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
 
                             // Remove this specific contact's signatory from the contract draft sessions
                             if ($contactCode == 'TRAINEE' || $contactCode == 'SESSIONTRAINER') {
-                                $trainingSession = new Trainingsession($this->db);
-                                $signatory       = new SaturneSignature($this->db, 'dolimeet', $trainingSession->element);
-                                $role            = ($contactCode == 'TRAINEE') ? 'Trainee' : 'SessionTrainer';
-                                $elementType     = ($contactSource == 'internal') ? 'user' : 'socpeople';
+                                $signatory   = new SaturneSignature($this->db, 'dolimeet', $trainingSession->element);
+                                $role        = ($contactCode == 'TRAINEE') ? 'Trainee' : 'SessionTrainer';
+                                $elementType = ($contactSource == 'internal') ? 'user' : 'socpeople';
 
-                                $trainingSessions = $trainingSession->fetchAll('', '', 0, 0, ['customsql' => 't.status = ' . Session::STATUS_DRAFT . ' AND t.fk_contrat = ' . $object->id]);
-                                if (is_array($trainingSessions) && !empty($trainingSessions)) {
-                                    foreach ($trainingSessions as $session) {
-                                        $signatories = $signatory->fetchAll('', '', 0, 0, ['customsql' => "fk_object = " . $session->id . " AND object_type = '" . $trainingSession->element . "' AND role = '" . $role . "' AND element_id = " . $contactID . " AND element_type = '" . $elementType . "' AND status = 1"]);
-                                        if (is_array($signatories) && !empty($signatories)) {
-                                            foreach ($signatories as $signatoryToDelete) {
-                                                $signatoryToDelete->setDeleted($user, true);
-                                            }
+                                foreach ($trainingSessions as $session) {
+                                    $signatories = $signatory->fetchAll('', '', 0, 0, ['customsql' => "fk_object = " . $session->id . " AND object_type = '" . $trainingSession->element . "' AND role = '" . $role . "' AND element_id = " . $contactID . " AND element_type = '" . $elementType . "' AND status = 1"]);
+                                    if (is_array($signatories) && !empty($signatories)) {
+                                        foreach ($signatories as $signatoryToDelete) {
+                                            $signatoryToDelete->setDeleted($user, true);
                                         }
                                     }
                                 }
                             }
 
-                            // Refresh the public note, excluding the trainee being removed (its link is not deleted yet)
-                            if ($contactCode == 'TRAINEE') {
+                            // Refresh the public note, excluding the trainee being removed (formation note only; its link is not deleted yet)
+                            if ($contactCode == 'TRAINEE' && !empty($object->array_options['options_trainingsession_type'])) {
                                 $object->fetchObjectLinked(null, 'propal', $object->id, 'contrat');
                                 if (isset($object->linkedObjects['propal']) && !empty($object->linkedObjects['propal']) && count($object->linkedObjects['propal']) == 1) {
                                     $propal = array_shift($object->linkedObjects['propal']);


### PR DESCRIPTION
Closes #845

## Problème
Le handler `CONTRAT_DELETE_CONTACT` ajouté en #816 ne nettoyait le signataire du contact retiré que si l'extrafield `options_trainingsession_type` du contrat était renseigné. Or des contrats de formation réels ont ce champ vide (`0`) tout en portant des signataires de session créés par `TRAININGSESSION_CREATE` (qui, lui, n'est pas gardé dessus). Pour ces contrats, retirer un `TRAINEE`/`SESSIONTRAINER` laissait le signataire en place → il continuait d'apparaître dans les mails de questionnaires/convocation (symptôme de #563).

## Correctif
Garder le **nettoyage du signataire** sur la **présence de sessions brouillon** (au lieu de l'extrafield). Le **rafraîchissement de la note publique** reste gardé sur `options_trainingsession_type`. No-op pour les contrats non-formation (aucune session de ce type).

## Vérification (instance locale, transactions annulées)
- Contrat `trainingsession_type=0` (12 signataires `Trainee`) → **seul** le signataire du contact retiré passe en `status=-1` (exclu de `fetchSignatory status>0`), les autres intacts. ✅
- Contrat `trainingsession_type=1` → comportement inchangé. ✅
- Rollback → aucune persistance. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)