### PR TITLE
#848 [Hook] fix: guard propal extrafield label decoration, drop deprecated trainingsession_service

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -202,9 +202,12 @@ class ActionsDolimeet
         }
 
         if (strpos($parameters['context'], 'propalcard') !== false) {
-            $extrafields->attributes['propal']['label']['trainingsession_type']     = $picto . $langs->transnoentities($extrafields->attributes['propal']['label']['trainingsession_type']);
-            $extrafields->attributes['propal']['label']['trainingsession_service']  = $picto . $langs->transnoentities($extrafields->attributes['propal']['label']['trainingsession_service']);
-            $extrafields->attributes['propal']['label']['trainingsession_location'] = $picto . $langs->transnoentities($extrafields->attributes['propal']['label']['trainingsession_location']);
+            $propalExtraFieldsNames = ['trainingsession_type', 'trainingsession_location'];
+            foreach ($propalExtraFieldsNames as $propalExtraFieldsName) {
+                if (isset($extrafields->attributes['propal']['label'][$propalExtraFieldsName])) {
+                    $extrafields->attributes['propal']['label'][$propalExtraFieldsName] = $picto . $langs->transnoentities($extrafields->attributes['propal']['label'][$propalExtraFieldsName]);
+                }
+            }
 
             if (empty(GETPOST('options_trainingsession_type', 'int'))) {
                 $extrafields->attributes['propal']['hidden']['trainingsession_location'] = 1;


### PR DESCRIPTION
Closes #848

## Problem
Opening a proposal (propal) card emits:

`Warning: Undefined array key "trainingsession_service" in htdocs/custom/dolimeet/class/actions_dolimeet.class.php on line 206`

## Cause
`formObjectOptions()` decorated the `trainingsession_service` extrafield label on `propal` unconditionally. That extrafield is deleted from `propal` by the backward-compatibility migration in `modDoliMeet::init()` (`DOLIMEET_EXTRAFIELDS_BACKWARD_COMPATIBILITY`), so once the migration runs the key no longer exists. `trainingsession_type` / `trainingsession_location` are not deleted from propal, which is why only that one key warned.

## Fix
- Replace the three direct label assignments with a guarded loop using `isset()`, mirroring the existing pattern earlier in the same method.
- Drop the deprecated `trainingsession_service` reference (no longer present on propal).
- Keep `trainingsession_type` and `trainingsession_location`, which remain on propal.

`php -l` passes.