### PR TITLE
fix: prevent sql error in completeTabsHead when object is a ticket

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -1260,6 +1260,8 @@ class ActionsDolimeet
             require_once __DIR__ . '/session.class.php';
             $session = new Session($db);
             switch ($parameters['object']->element ?? '') {
+                case 'ticket':
+                    return 0; // Tickets are not natively supported by dolimeet_session
                 case 'societe' :
                     $objectElement = 'soc';
                     break;


### PR DESCRIPTION
Fixes #850. There is a silent SQL error in \ctions_dolimeet.class.php\ in the \completeTabsHead\ hook when the object element is a ticket. The code attempts to query \llx_dolimeet_session\ with \	.fk_ticket\, but this field does not exist. The fix adds a case to return early when the object element is a ticket.