### PR TITLE
#852 [Session] fix: create missing llx_categorie_* tables for session subtypes

### DIFF
--- a/sql/session/llx_categorie_audit.key.sql
+++ b/sql/session/llx_categorie_audit.key.sql
@@ -1,0 +1,20 @@
+-- Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+ALTER TABLE llx_categorie_audit ADD PRIMARY KEY pk_categorie_audit (fk_categorie, fk_audit);
+ALTER TABLE llx_categorie_audit ADD INDEX idx_categorie_audit_fk_categorie (fk_categorie);
+ALTER TABLE llx_categorie_audit ADD INDEX idx_categorie_audit_fk_audit (fk_audit);
+ALTER TABLE llx_categorie_audit ADD CONSTRAINT fk_categorie_audit_categorie_rowid FOREIGN KEY (fk_categorie) REFERENCES llx_categorie (rowid);
+ALTER TABLE llx_categorie_audit ADD CONSTRAINT fk_categorie_audit_dolimeet_session_rowid FOREIGN KEY (fk_audit) REFERENCES llx_dolimeet_session (rowid);

--- a/sql/session/llx_categorie_audit.sql
+++ b/sql/session/llx_categorie_audit.sql
@@ -1,0 +1,20 @@
+-- Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+CREATE TABLE llx_categorie_audit(
+  fk_categorie integer NOT NULL,
+  fk_audit     integer NOT NULL,
+  import_key   varchar(14)
+) ENGINE=innodb;

--- a/sql/session/llx_categorie_meeting.key.sql
+++ b/sql/session/llx_categorie_meeting.key.sql
@@ -1,0 +1,20 @@
+-- Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+ALTER TABLE llx_categorie_meeting ADD PRIMARY KEY pk_categorie_meeting (fk_categorie, fk_meeting);
+ALTER TABLE llx_categorie_meeting ADD INDEX idx_categorie_meeting_fk_categorie (fk_categorie);
+ALTER TABLE llx_categorie_meeting ADD INDEX idx_categorie_meeting_fk_meeting (fk_meeting);
+ALTER TABLE llx_categorie_meeting ADD CONSTRAINT fk_categorie_meeting_categorie_rowid FOREIGN KEY (fk_categorie) REFERENCES llx_categorie (rowid);
+ALTER TABLE llx_categorie_meeting ADD CONSTRAINT fk_categorie_meeting_dolimeet_session_rowid FOREIGN KEY (fk_meeting) REFERENCES llx_dolimeet_session (rowid);

--- a/sql/session/llx_categorie_meeting.sql
+++ b/sql/session/llx_categorie_meeting.sql
@@ -1,0 +1,20 @@
+-- Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+CREATE TABLE llx_categorie_meeting(
+  fk_categorie integer NOT NULL,
+  fk_meeting   integer NOT NULL,
+  import_key   varchar(14)
+) ENGINE=innodb;

--- a/sql/session/llx_categorie_trainingsession.key.sql
+++ b/sql/session/llx_categorie_trainingsession.key.sql
@@ -1,0 +1,20 @@
+-- Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+ALTER TABLE llx_categorie_trainingsession ADD PRIMARY KEY pk_categorie_trainingsession (fk_categorie, fk_trainingsession);
+ALTER TABLE llx_categorie_trainingsession ADD INDEX idx_categorie_trainingsession_fk_categorie (fk_categorie);
+ALTER TABLE llx_categorie_trainingsession ADD INDEX idx_categorie_trainingsession_fk_trainingsession (fk_trainingsession);
+ALTER TABLE llx_categorie_trainingsession ADD CONSTRAINT fk_categorie_trainingsession_categorie_rowid FOREIGN KEY (fk_categorie) REFERENCES llx_categorie (rowid);
+ALTER TABLE llx_categorie_trainingsession ADD CONSTRAINT fk_categorie_trainingsession_dolimeet_session_rowid FOREIGN KEY (fk_trainingsession) REFERENCES llx_dolimeet_session (rowid);

--- a/sql/session/llx_categorie_trainingsession.sql
+++ b/sql/session/llx_categorie_trainingsession.sql
@@ -1,0 +1,20 @@
+-- Copyright (C) 2021-2026 EVARISK <technique@evarisk.com>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+CREATE TABLE llx_categorie_trainingsession(
+  fk_categorie       integer NOT NULL,
+  fk_trainingsession integer NOT NULL,
+  import_key         varchar(14)
+) ENGINE=innodb;


### PR DESCRIPTION
## Changements

Création des tables de liaison catégorie manquantes pour les sous-types de session, sur le modèle de `llx_categorie_session` :

- `llx_categorie_trainingsession` (colonnes `fk_categorie`, `fk_trainingsession`) + clés/index/FK
- `llx_categorie_meeting` (colonnes `fk_categorie`, `fk_meeting`) + clés/index/FK
- `llx_categorie_audit` (colonnes `fk_categorie`, `fk_audit`) + clés/index/FK

Les fichiers sont placés dans `sql/session/` ; ils sont créés automatiquement par `modDoliMeet::init()` → `_load_tables('/dolimeet/sql/session/')` à la réactivation/upgrade du module. Les FK référencent `llx_dolimeet_session(rowid)` (table partagée par tous les sous-types).

## Pourquoi

Le hook `constructCategory` déclare 4 codes (`meeting`, `trainingsession`, `audit`, `session`) mais seule `llx_categorie_session` existait. Toute méthode générique de `Categorie` (`containing`, `setCategoriesCommon`, `add_type`, `del_type`, `getObjectsInCateg`) appelée avec l'un des 3 autres codes générait `DB_ERROR_NOSUCHTABLE` (page d'erreur fatale).

## Fichiers ajoutés

- `sql/session/llx_categorie_trainingsession.sql`
- `sql/session/llx_categorie_trainingsession.key.sql`
- `sql/session/llx_categorie_meeting.sql`
- `sql/session/llx_categorie_meeting.key.sql`
- `sql/session/llx_categorie_audit.sql`
- `sql/session/llx_categorie_audit.key.sql`

## Tests

- [ ] Réactiver le module → vérifier la création des 3 tables.
- [ ] Créer une session de formation depuis un produit/service → plus de page d'erreur.
- [ ] Mass action « Affecter tag » sur la liste des sessions → OK.
- [ ] Ajout d'objet depuis une fiche catégorie (meeting/trainingsession/audit) → OK.

## Note pour la review (cohérence des données)

⚠️ La PR #835 force le chemin **carte** (`Session::setCategories`) vers `'session'`, et les lectures de la carte (`session_card.php`) sont codées en dur sur `'session'` → la carte lit/écrit dans `llx_categorie_session`. Avec ces nouvelles tables, les chemins **directs** (mass action, fiche catégorie) écrivent dans `llx_categorie_{sous-type}`. Conséquence : les catégories posées via la carte et via les chemins directs ne vivent pas dans la même table.

Ce correctif **élimine tous les crashs** `DB_ERROR_NOSUCHTABLE`. Si on veut en plus une cohérence totale (une seule table par objet), il faudra trancher entre : (a) tout router vers `session` (mapping `cat_table`/`cat_fk` dans le hook + suppression des tables par sous-type), ou (b) aligner les lectures/écritures de la carte sur le sous-type et retirer l'override #835. À discuter.

## Issue

Closes #852
