### PR TITLE
#854 [Session] fix: guard $_POST['fk_soc'] read on session create form

### DIFF
--- a/view/session/session_card.php
+++ b/view/session/session_card.php
@@ -270,7 +270,7 @@ if ($action == 'create') {
             $_POST['date_endmin']  = $now['minutes'];
         }
 
-        if ($_POST['fk_soc'] == -1) {
+        if (GETPOSTISSET('fk_soc') && $_POST['fk_soc'] == -1) {
             $_POST['fk_soc'] = 0;
         }
     }


### PR DESCRIPTION
Closes #854

## Problem
`Warning: Undefined array key "fk_soc" in htdocs/custom/dolimeet/view/session/session_card.php on line 273` when opening the session create form.

## Cause
The non-model branch of the `action == 'create'` block reads `$_POST['fk_soc']` directly to normalize the "no thirdparty" select value (`-1` → `0`). On initial display (GET link, no POST), the key does not exist → PHP 8 warning.

## Fix
Guard the read with `GETPOSTISSET('fk_soc')`, consistent with the existing `GETPOSTISSET()` usage in the same file. Behavior unchanged: nothing to normalize when `fk_soc` is absent.