### PR TITLE
#856 [Lib] fix: exclude deleted sessions from training service duration match

### DIFF
--- a/lib/dolimeet_trainingsession.lib.php
+++ b/lib/dolimeet_trainingsession.lib.php
@@ -69,6 +69,7 @@ function trainingsession_function_lib1()
                 FROM ' . MAIN_DB_PREFIX . 'dolimeet_session ds
                 WHERE ds.fk_element = t.rowid
                     AND ds.model = 1
+                    AND ds.status >= 0
                     AND ds.element_type = \'service\'
                     AND ds.date_start IS NOT NULL
                     AND ds.date_end IS NOT NULL


### PR DESCRIPTION
## Closes #856

### Problème
Un service de formation prêt à l'emploi (jour 1, clone) n'apparaît pas dans la liste des services de formation à la création d'une proposition commerciale, alors qu'un service équivalent (jour 2) apparaît.

### Cause
`trainingsession_function_lib1()` retient un service quand la somme des durées de ses sessions modèles est égale à la durée du produit (`HAVING SUM(ds.duration) = t.duration * 3600`). Le sous-`SELECT` ne filtrait pas le statut : une session supprimée (`status = -1`) restée en base était encore additionnée, cassant l'égalité et excluant à tort le service.

### Correctif
Ajout de `AND ds.status >= 0` dans le sous-`SELECT` pour exclure les sessions supprimées de la somme des durées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
