### PR TITLE
#862 [Session] fix: skip session count for objects without a session FK

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -1276,7 +1276,16 @@ class ActionsDolimeet
                     $objectElement = $parameters['object']->element ?? '';
                     break;
             }
-            $filter  = $filter ?? 't.status >= 0 AND t.fk_' . $objectElement . ' = ' . ($parameters['object']->id ?? 0);
+            // Only objects owning a dedicated foreign key on the session table can be linked
+            // to a session. For any other object (e.g. digiriskelement) t.fk_<element> does not
+            // exist and would raise a SQL error, so skip the count silently.
+            if (!isset($filter)) {
+                $fkField = 'fk_' . $objectElement;
+                if (!array_key_exists($fkField, $session->fields)) {
+                    return 0;
+                }
+                $filter = 't.status >= 0 AND t.' . $fkField . ' = ' . ($parameters['object']->id ?? 0);
+            }
             $filter .= GETPOST('object_type') ? " AND t.type = '" . GETPOST('object_type') . "'" : '';
             $sessions = $session->fetchAll('', '', 0, 0, ['customsql' => $filter]);
             if (is_array($sessions) && !empty($sessions)) {


### PR DESCRIPTION
Closes #862

## Problème
`ActionsDolimeet::completeTabsHead()` (contexte `main`, exécuté sur **toute** page objet) construisait le filtre `t.fk_<element>` pour tout objet non géré explicitement. Pour un objet sans colonne dédiée sur `llx_dolimeet_session` (ex. **digiriskelement**), cela donnait `t.fk_digiriskelement` → **erreur SQL** à chaque affichage de la fiche.

```
WHERE t.entity IN (1) AND (t.status >= 0 AND t.fk_digiriskelement = 1)
--> DB_ERROR : Champ 't.fk_digiriskelement' inconnu
```

## Correctif
Ne construire le filtre que si la clé étrangère `fk_<element>` **existe** dans `Session->fields` ; sinon `return 0` (comme le cas `ticket`).

```php
if (!isset($filter)) {
    $fkField = 'fk_' . $objectElement;
    if (!array_key_exists($fkField, $session->fields)) {
        return 0;
    }
    $filter = 't.status >= 0 AND t.' . $fkField . ' = ' . ($parameters['object']->id ?? 0);
}
```

- Cas supportés (`societe`→fk_soc, `contract`→fk_contrat, `project`→fk_project, `product`→fk_element) : **filtre identique**, comptage préservé (le constructeur `Session` par défaut conserve ces champs).
- Objets non liables : plus d'erreur SQL, comptage ignoré silencieusement.

## Vérification
Sur la fiche élément Digirisk (`digiriskelement_risk.php`) : **2 requêtes en échec → 0** (DebugBar), page inchangée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)