### PR TITLE
#864 [Trigger] fix: load dolibarr_lib.php on every CONTRACT_CREATE path

### DIFF
--- a/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
+++ b/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
@@ -355,8 +355,12 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
 
             case 'CONTRACT_CREATE' :
                 if (GETPOST('options_trainingsession_type', 'int') > 0) {
+                    // Load Dolibarr libraries
+                    require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';
+
                     // Load DoliMeet libraries
                     require_once __DIR__ . '/../../lib/dolimeet_function.lib.php';
+                    require_once __DIR__ . '/../../lib/dolibarr_lib.php';
 
                     $propal       = new Propal($this->db);
                     $product      = new Product($this->db);
@@ -390,7 +394,6 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
                         // Load DoliMeet libraries
                         require_once __DIR__ . '/../../class/trainingsession.class.php';
                         require_once __DIR__ . '/../../lib/dolimeet_trainingsession.lib.php';
-                        require_once __DIR__ . '/../../lib/dolibarr_lib.php';
 
                         $trainingSession = new Trainingsession($this->db);
 
@@ -438,10 +441,11 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
                     $object->validate($user);
 
                     $contactSingle = listeContact($object, -1, 'internal', 0, 'SALESREPSIGN');
-
-                    $contact = new Contact($this->db);
-                    $contact->fetch($contactSingle[0]['rowid']);
-                    $contact->setValueFrom('mandatory_signature', 1, 'element_contact', $contactSingle[0]['rowid'], 'int', '', $user, '', '');
+                    if (is_array($contactSingle) && !empty($contactSingle)) {
+                        $contact = new Contact($this->db);
+                        $contact->fetch($contactSingle[0]['rowid']);
+                        $contact->setValueFrom('mandatory_signature', 1, 'element_contact', $contactSingle[0]['rowid'], 'int', '', $user, '', '');
+                    }
                 }
                 break;
         }


### PR DESCRIPTION
Closes #864

## Problème

La création d'un contrat avec `trainingsession_type` renseigné **sans propale liée** partait en erreur fatale :

```
PHP Fatal error: Uncaught Error: Call to undefined function listeContact() in
core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php:440
#3 contrat/card.php(462): Contrat->create()
```

Le `require_once` de `lib/dolibarr_lib.php` — qui définit la surcharge `listeContact()` (#811) — était **imbriqué dans le bloc `if (isset($object->linked_objects['propal']))`**, alors que l'appel `listeContact()` se fait *après* la fermeture de ce bloc. Un contrat créé directement ne chargeait donc jamais la lib.

## Correctif

- `dolibarr_lib.php` remonté en tête du `case 'CONTRACT_CREATE'`, à côté de `dolimeet_function.lib.php` : tous les chemins qui atteignent l'appel disposent de la fonction. Le `require_once` interne, devenu redondant, est supprimé.
- Ajout du `require_once` de `contact/class/contact.class.php` : la classe `Contact` instanciée juste après n'est chargée nulle part dans la chaîne d'inclusion de `contrat/card.php` (le core ne l'inclut qu'à la volée dans `CommonObject::fetch_contact()`). Elle ne tenait que par chance, via un autre module l'ayant déjà incluse.
- Garde sur `$contactSingle` : `listeContact()` renvoie `-1` en cas d'erreur SQL et `[]` sans contact `SALESREPSIGN`, alors que `$contactSingle[0]['rowid']` était lu sans vérification.

Le chemin « contrat depuis propale » est inchangé (le `require_once` est simplement chargé plus tôt, il est idempotent).

## Tests

Reproduction puis validation en local (Dolibarr 22, DoliMeet actif), création d'un contrat sur `contrat/card.php` avec `trainingsession_type = ActionFormation` et **sans propale liée** :

- **avant** : `Fatal error: Call to undefined function listeContact()` à la ligne 440, contrat non exploitable ;
- **après** : contrat `CT2607-0523` créé et affiché sans erreur. Le chemin nominal complet s'exécute — `llx_contrat.statut = 1` (le `validate()` qui suit l'appel a bien tourné) et le lien `llx_element_contact` de type `SALESREPSIGN` (internal) porte `mandatory_signature = 1`.
