### PR TITLE
#866 [Trigger] fix: drop useless Contact fetch on CONTRACT_CREATE mandatory_signature

### DIFF
--- a/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
+++ b/core/triggers/interface_99_modDoliMeet_DoliMeetTriggers.class.php
@@ -355,9 +355,6 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
 
             case 'CONTRACT_CREATE' :
                 if (GETPOST('options_trainingsession_type', 'int') > 0) {
-                    // Load Dolibarr libraries
-                    require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';
-
                     // Load DoliMeet libraries
                     require_once __DIR__ . '/../../lib/dolimeet_function.lib.php';
                     require_once __DIR__ . '/../../lib/dolibarr_lib.php';
@@ -440,11 +437,10 @@ class InterfaceDoliMeetTriggers extends DolibarrTriggers
 
                     $object->validate($user);
 
+                    // 'rowid' is the ID of the llx_element_contact link, not the ID of the contact
                     $contactSingle = listeContact($object, -1, 'internal', 0, 'SALESREPSIGN');
                     if (is_array($contactSingle) && !empty($contactSingle)) {
-                        $contact = new Contact($this->db);
-                        $contact->fetch($contactSingle[0]['rowid']);
-                        $contact->setValueFrom('mandatory_signature', 1, 'element_contact', $contactSingle[0]['rowid'], 'int', '', $user, '', '');
+                        $object->setValueFrom('mandatory_signature', 1, 'element_contact', $contactSingle[0]['rowid'], 'int', '', $user, '', '');
                     }
                 }
                 break;


### PR DESCRIPTION
Closes #866

Suite de #865 (nettoyage volontairement laissé de côté pour que le hotfix reste sans changement de comportement).

## Problème

Le passage à `mandatory_signature` sur `CONTRACT_CREATE` instanciait un `Contact` puis le chargeait avec `$contactSingle[0]['rowid']`. Deux erreurs :

1. `rowid` est l'id de la **ligne de liaison** `llx_element_contact`, pas l'id du contact — c'est `id` qui porte l'id de la personne ;
2. la source demandée est `internal`, donc la personne liée est un `User`, pas un `Contact`.

Ce `fetch()` n'était inoffensif que parce que `setValueFrom()` cible explicitement la table (`element_contact`) et l'id qu'on lui passe — lui correct — et ignore l'objet porteur.

## Correctif

```diff
-$contact = new Contact($this->db);
-$contact->fetch($contactSingle[0]['rowid']);
-$contact->setValueFrom('mandatory_signature', 1, 'element_contact', $contactSingle[0]['rowid'], 'int', '', $user, '', '');
+$object->setValueFrom('mandatory_signature', 1, 'element_contact', $contactSingle[0]['rowid'], 'int', '', $user, '', '');
```

`$object` est le `Contrat`, déjà un `CommonObject` : même `UPDATE` sur `llx_element_contact`. Le `require_once` de `contact/class/contact.class.php` ajouté en #865 devient inutile et est retiré (la classe n'est plus utilisée dans le trigger).

Audit des autres usages de `listeContact()` / `liste_contact()` du module : RAS, `$contact['id']` est bien utilisé partout où il s'agit de la personne, et `core/ajax/testajax.php` utilise `new Contact()` comme simple véhicule de `setValueFrom()` (sans `fetch()`).

## Tests

Local (Dolibarr 22, DoliMeet actif), création d'un contrat sans propale liée avec `trainingsession_type = ActionFormation` — résultat identique à avant le nettoyage :

- contrat `CT2607-0524` créé et validé (`llx_contrat.statut = 1`) ;
- le lien `llx_element_contact` de type `SALESREPSIGN` (internal) porte bien `mandatory_signature = 1`.
