### PR TITLE
#868 [JS] fix: keep core change() handler on propal product combo

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -662,7 +662,11 @@ class ActionsDolimeet
                 ?>
                 <script>
                     $(document).ready(function() {
-                        $('#idprod').replaceWith(<?php echo json_encode($out); ?>);
+                        // Only swap the <option> list, never the <select> itself: objectline_create.tpl.php
+                        // binds .change() on #idprod before this footer hook runs, and replaceWith() would
+                        // destroy that handler -- the product description/price/vat AJAX would never fire.
+                        var newOptions = $('<div></div>').html(<?php echo json_encode($out); ?>).find('#idprod').html();
+                        $('#idprod').html(newOptions).val('-1').trigger('change.select2');
                     });
                 </script>
                 <?php


### PR DESCRIPTION
Closes #868

## Problème

Sur une propale formation (`trainingsession_type = 1`), la description du produit ne se reportait plus dans la ligne à la sélection dans le combo.

## Cause

Le hook `printCommonFooter` remplaçait tout le `<select id="idprod">` :

```js
$('#idprod').replaceWith(<?php echo json_encode($out); ?>);
```

`replaceWith()` détruit l'élément DOM **et tous ses handlers jQuery**. Le core (`htdocs/core/tpl/objectline_create.tpl.php`) avait attaché juste avant sur `#idprod` le `.change()` qui déclenche `product/ajax/products.php?action=fetch` — celui qui remplit description, prix, TVA, unités et dates. Le hook tournant en footer, ce handler partait avec l'ancien élément : l'AJAX ne partait jamais.

Seule la description était visible côté utilisateur car `addline` récupère le prix du produit côté serveur quand le champ est vide — pas la description.

## Correctif

Ne remplacer que la liste des `<option>`, jamais le `<select>` : l'élément et son handler survivent, le filtre formations reste appliqué.

## Tests (Playwright, Dolibarr 22, propale formation réelle)

| | Avant | Après |
|---|---|---|
| Appel `products.php?action=fetch` | jamais | ✅ |
| Description CKEditor | vide | ✅ 815 car. |
| Prix | vide | ✅ 190,00 |
| Filtre formations DoliMeet | 28 options | ✅ 28 options |
| Combo select2 | OK | ✅ OK (clic réel + recherche) |

Ligne réellement ajoutée via l'UI puis vérifiée en base : `description` correctement remplie. Contrôle croisé sur une propale sans DoliMeet : comportement identique au core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)