### PR TITLE
#875 [Lang] fix: traduction fr_FR manquante pour la clé Contract

### DIFF
--- a/langs/fr_FR/dolimeet.lang
+++ b/langs/fr_FR/dolimeet.lang
@@ -174,6 +174,7 @@ OfTrainingsession                     = de la session de formation
 TrainingsessionList                   = Liste des sessions de formation
 TrainingSessionList                   = Liste des sessions de formation
 TrainingSessionCreate                 = Créer une session de formation
+Contract                              = Contrat
 NewTrainingsession                    = Nouvelle session de formation
 ModifyTrainingsession                 = Modifier une session de formation
 ActionFormation                       = Action de formation


### PR DESCRIPTION
Closes #875

## Problème

`langs/en_US/dolimeet.lang` (ligne 99) déclare `Contract = Contract`, mais la clé était **absente de `langs/fr_FR/dolimeet.lang`**.

Dolibarr complète le fichier de la langue courante avec le fichier de référence en_US : `tab_translate['Contract']` était donc renseignée avec la valeur anglaise dès le chargement de la langue de DoliMeet.

## Pourquoi ça débordait sur les autres modules

`Translate::load()` **n'écrase jamais une clé déjà renseignée** (`core/class/translate.class.php`, ligne 370). Une fois la clé posée en anglais, aucun `$langs->load('contracts')` ultérieur ne pouvait la corriger : « Contract » s'affichait à la place de « Contrat » sur toutes les pages chargées ensuite.

Constaté sur les listes DigiQuali (contrôles et questionnaires), dont l'en-tête de colonne vient de `'langs' => 'Contract'` dans la métadonnée saturne. Un correctif côté DigiQuali a été tenté puis abandonné : la clé est polluée avant même que la page ne s'exécute, y compris avec le paramètre `forceloadifalreadynotfound` de `load()`.

## Correctif

Une ligne : la traduction française manquante. La clé n'est référencée nulle part dans le code de DoliMeet, elle ne sert qu'à traduire le label générique de la métadonnée saturne.

## Vérification

En-tête de la colonne Contrat sur les listes DigiQuali, base `dolibarr_22_evarisk`, langue fr_FR : « Contract » avant, **« Contrat » après**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)