### PR TITLE
#873 [Hook] fix: filter the satisfaction survey on the sheet configured for the contact role

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -392,9 +392,10 @@ class ActionsDolimeet
                                 arsort($surveyIDs);
                                 foreach ($surveyIDs as $surveyID) {
                                     $confName = 'DOLIMEET_' . $contact['code'] . '_SATISFACTION_SURVEY_SHEET';
-                                    //$filter   = ' AND e.fk_sheet = ' . $conf->global->$confName;
                                     if (getDolGlobalInt($confName) > 0) {
-                                        if ($signatory->checkSignatoryHasObject($surveyID, $survey->table_element, $contact['id'], $contact['source'] == 'internal' ? 'user' : 'socpeople', '')) {
+                                        // Restrict to the survey built from the sheet configured for this contact role, otherwise a contact holding several roles shows the same survey on each of its rows
+                                        $filter = ' AND e.fk_sheet = ' . getDolGlobalInt($confName);
+                                        if ($signatory->checkSignatoryHasObject($surveyID, $survey->table_element, $contact['id'], $contact['source'] == 'internal' ? 'user' : 'socpeople', $filter)) {
                                             $survey->fetch($surveyID);
                                             $signatory->fetch($signatory->id);
                                             $outputLine[$contact['rowid']] = '<td class="tdoverflowmax200">';


### PR DESCRIPTION
Closes #873

## Problème

Sur l'onglet **Contacts/Adresses** d'une session de formation, un contact portant plusieurs rôles affichait **le même questionnaire de satisfaction sur chacune de ses lignes** (même lien public, même `track_id`).

## Cause

Dans le hook `printFieldListOption` (contexte `contractcontactcard`), la recherche du questionnaire parcourt tous les questionnaires liés au contrat et retient le premier dont le contact est signataire — sans vérifier que le `fk_sheet` du questionnaire correspond au modèle configuré pour **ce rôle** (`DOLIMEET_<CODE>_SATISFACTION_SURVEY_SHEET`). Le filtre prévu pour cela était présent mais commenté.

## Correctif

Le filtre `fk_sheet` est rétabli et passé à `checkSignatoryHasObject()` (via `getDolGlobalInt()` plutôt que `$conf->global->$confName`).

## Vérification

Contrat de test : un contact avec les rôles `CUSTOMER` (sheet 31) et `TRAINEE` (sheet 29), seul le questionnaire `TRAINEE` existant.

| ligne | rôle | avant | après |
|---|---|---|---|
| 9798 | CUSTOMER | survey 820 (sheet 29) — **faux** | bouton `+` (aucun questionnaire pour ce rôle) |
| 9803 | TRAINEE | survey 820 (sheet 29) | survey 820 (sheet 29) |

Les lignes des autres contacts sont inchangées. Contrôlé en base et sur le rendu réel de la page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
