### PR TITLE
Fix: Undefined variable \ warning in actions_dolimeet.class.php

### DIFF
--- a/class/actions_dolimeet.class.php
+++ b/class/actions_dolimeet.class.php
@@ -157,7 +157,7 @@ class ActionsDolimeet
                 'js'  => '/custom/dolimeet/js/dolimeet.min.js'
             ];
 
-            $out .= '<!-- Includes JS added by module saturne -->';
+            $out = '<!-- Includes JS added by module saturne -->';
             $out .= '<script src="' . dol_buildpath($resourcesRequired['js'], 1) . '"></script>';
 
             $this->resprints = $out;


### PR DESCRIPTION
Resolves #878

When the context contains \	hirdpartycontact\, the variable \\\ is concatenated (\\ .= ...\) without being initialized, triggering a PHP warning: \Warning: Undefined variable \ in .../custom/dolimeet/class/actions_dolimeet.class.php\. This PR initializes the variable properly.